### PR TITLE
urlencode username/password in DSN connection string

### DIFF
--- a/src/Doctrine1/Service/ConfigurationFactory.php
+++ b/src/Doctrine1/Service/ConfigurationFactory.php
@@ -48,8 +48,8 @@ class ConfigurationFactory implements FactoryInterface
     protected function connect($name, $options, $cacheDriver)
     {
         $conn = Doctrine_Manager::connection(
-            $options['system'] . '://' . $options['user'] . ':'
-            . $options['password'] . '@'
+            $options['system'] . '://' . urlencode($options['user']) . ':'
+            . urlencode($options['password']) . '@'
             . $options['server'] . ':' . $options['port'] . '/'
             . $options['database'],
             $name


### PR DESCRIPTION
PHP 5.6.28 and 7.0.13 changed the behavior of how certain characters are handled in parse_url (notably `#`), so if a username or password were to contain such a character, it would no longer be handled properly. Urlencoding these values allows it to continue functioning (and has been confirmed to work in prior versions of PHP as well).

References:
https://bugs.php.net/bug.php?id=73192
https://bugs.php.net/bug.php?id=73500
https://3v4l.org/UQLQm
